### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Ft_ls
 Unix "ls" function recoded.
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/JBTH3H4bhJWJ5FEzwurGnwZP/Zupirio/Ft_ls'>  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/JBTH3H4bhJWJ5FEzwurGnwZP/Zupirio/Ft_ls.svg' /></a>
+


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8